### PR TITLE
Fix bottomless replication subproject link in libsql-server readme

### DIFF
--- a/libsql-server/README.md
+++ b/libsql-server/README.md
@@ -80,7 +80,7 @@ and run `sqld` with `--enable-bottomless-replication` parameter:
 sqld --http-listen-addr=127.0.0.1:8000 --enable-bottomless-replication
 ```
 
-[bottomless replication subproject]: ./bottomless
+[bottomless replication subproject]: ../bottomless
 [SQLite WAL]: https://www.sqlite.org/wal.html
 
 ### Configuration
@@ -110,7 +110,7 @@ RUSTFLAGS='--cfg uuid_unstable' cargo install bottomless-cli
 For usage examples and description, refer to the [bottomless-cli
 documentation].
 
-[bottomless-cli documentation]: ./bottomless#cli
+[bottomless-cli documentation]: ../bottomless#cli
 
 ## License
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1331](https://togithub.com/tursodatabase/libsql/pull/1331).



The original branch is fork-1331-marcob/patch-2