### PR TITLE
server: return 429 when dbcreatetimeout is hit

### DIFF
--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -172,7 +172,7 @@ impl IntoResponse for &Error {
             InvalidBatchStep(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             NotAuthorized(_) => self.format_err(StatusCode::UNAUTHORIZED),
             ReplicatorExited => self.format_err(StatusCode::SERVICE_UNAVAILABLE),
-            DbCreateTimeout => self.format_err(StatusCode::SERVICE_UNAVAILABLE),
+            DbCreateTimeout => self.format_err(StatusCode::TOO_MANY_REQUESTS),
             BuilderError(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             Blocked(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),
             Json(_) => self.format_err(StatusCode::INTERNAL_SERVER_ERROR),


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1356](https://togithub.com/tursodatabase/libsql/pull/1356).



The original branch is upstream/lucio/return-400-dbcreatetimeout