### PR TITLE
bump libsql server v0.24.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3333,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ rusqlite = { package = "libsql-rusqlite", path = "vendored/rusqlite", version = 
 # Config for 'cargo dist'
 [workspace.metadata.dist]
 # The preferred cargo-dist version to use in CI (Cargo.toml SemVer syntax)
-cargo-dist-version = "0.13.3"
+cargo-dist-version = "0.14.1"
 # CI backends to support
 ci = ["github"]
 # The installers to generate for each app

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.7"
+version = "0.24.8"
 edition = "2021"
 default-run = "sqld"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1392](https://togithub.com/tursodatabase/libsql/pull/1392).



The original branch is upstream/bump-libsql-server-v0.24.8