### PR TITLE
[DO NOT MERGE] Backport a few changes to old 0.24.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3298,7 +3298,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.7"
+version = "0.24.8"
 dependencies = [
  "aes",
  "anyhow",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.7"
+version = "0.24.8"
 edition = "2021"
 default-run = "sqld"
 

--- a/libsql-server/src/connection/connection_manager.rs
+++ b/libsql-server/src/connection/connection_manager.rs
@@ -69,10 +69,13 @@ impl Deref for ConnectionManager {
     }
 }
 
-impl Default for ConnectionManager {
-    fn default() -> Self {
+impl ConnectionManager {
+    pub fn new(txn_timeout_duration: Duration) -> ConnectionManager {
         Self {
-            inner: Default::default(),
+            inner: Arc::new(ConnectionManagerInner {
+                txn_timeout_duration,
+                ..Default::default()
+            }),
         }
     }
 }

--- a/libsql-server/src/connection/libsql.rs
+++ b/libsql-server/src/connection/libsql.rs
@@ -31,7 +31,7 @@ use super::connection_manager::{
 use super::program::{
     check_describe_auth, check_program_auth, DescribeCol, DescribeParam, DescribeResponse, Vm,
 };
-use super::{MakeConnection, Program, RequestContext};
+use super::{MakeConnection, Program, RequestContext, TXN_TIMEOUT};
 
 pub struct MakeLibSqlConn<W> {
     db_path: PathBuf,
@@ -70,6 +70,8 @@ where
         block_writes: Arc<AtomicBool>,
         resolve_attach_path: ResolveNamespacePathFn,
     ) -> Result<Self> {
+        let txn_timeout = config_store.get().txn_timeout.unwrap_or(TXN_TIMEOUT);
+
         let mut this = Self {
             db_path,
             stats,
@@ -84,7 +86,7 @@ where
             encryption_config,
             block_writes,
             resolve_attach_path,
-            connection_manager: ConnectionManager::default(),
+            connection_manager: ConnectionManager::new(txn_timeout),
         };
 
         let db = this.try_create_db().await?;
@@ -173,7 +175,7 @@ impl LibSqlConnection<libsql_sys::wal::wrapper::PassthroughWalWrapper> {
             tokio::sync::watch::channel(None).1,
             Default::default(),
             Arc::new(|_| unreachable!()),
-            ConnectionManager::default(),
+            ConnectionManager::new(TXN_TIMEOUT),
         )
         .await
         .unwrap()

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -186,6 +186,7 @@ async fn handle_get_config<C: Connector>(
         heartbeat_url: config.heartbeat_url.clone().map(|u| u.into()),
         jwt_key: config.jwt_key.clone(),
         allow_attach: config.allow_attach,
+        txn_timeout_s: config.txn_timeout.map(|d| d.as_millis() as u64),
     };
 
     Ok(Json(resp))
@@ -232,6 +233,8 @@ struct HttpDatabaseConfig {
     jwt_key: Option<String>,
     #[serde(default)]
     allow_attach: bool,
+    #[serde(default)]
+    txn_timeout_s: Option<u64>,
 }
 
 async fn handle_post_config<C>(
@@ -252,6 +255,7 @@ async fn handle_post_config<C>(
     config.block_writes = req.block_writes;
     config.block_reason = req.block_reason;
     config.allow_attach = req.allow_attach;
+    config.txn_timeout = req.txn_timeout_s.map(Duration::from_secs);
     if let Some(size) = req.max_db_size {
         config.max_db_pages = size.as_u64() / LIBSQL_PAGE_SIZE;
     }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -127,6 +127,10 @@ where
             "/v1/namespaces/:namespace/create",
             post(handle_create_namespace),
         )
+        .route(
+            "/v1/namespaces/:namespace/checkpoint",
+            post(handle_checkpoint),
+        )
         .route("/v1/namespaces/:namespace", delete(handle_delete_namespace))
         .route("/v1/namespaces/:namespace/stats", get(stats::handle_stats))
         .route(
@@ -427,5 +431,13 @@ async fn handle_delete_namespace<C>(
         .namespaces
         .destroy(NamespaceName::from_string(namespace)?, prune_all)
         .await?;
+    Ok(())
+}
+
+async fn handle_checkpoint<C>(
+    State(app_state): State<Arc<AppState<C>>>,
+    Path(namespace): Path<NamespaceName>,
+) -> crate::Result<()> {
+    app_state.namespaces.checkpoint(namespace).await?;
     Ok(())
 }

--- a/libsql-server/src/lib.rs
+++ b/libsql-server/src/lib.rs
@@ -191,9 +191,11 @@ where
     }
 }
 
+#[tracing::instrument(skip(connection_maker))]
 async fn run_periodic_checkpoint<C>(
     connection_maker: Arc<C>,
     period: Duration,
+    namespace_name: NamespaceName,
 ) -> anyhow::Result<()>
 where
     C: MakeConnection,

--- a/libsql-server/src/namespace/mod.rs
+++ b/libsql-server/src/namespace/mod.rs
@@ -440,6 +440,7 @@ impl Namespace {
             join_set.spawn(run_periodic_checkpoint(
                 connection_maker.clone(),
                 checkpoint_interval,
+                name.clone(),
             ));
         }
 

--- a/libsql-server/src/namespace/store.rs
+++ b/libsql-server/src/namespace/store.rs
@@ -130,6 +130,19 @@ impl NamespaceStore {
         Ok(())
     }
 
+    pub async fn checkpoint(&self, namespace: NamespaceName) -> crate::Result<()> {
+        let entry = self
+            .inner
+            .store
+            .get_with(namespace.clone(), async { Default::default() })
+            .await;
+        let lock = entry.read().await;
+        if let Some(ns) = &*lock {
+            ns.checkpoint().await?;
+        }
+        Ok(())
+    }
+
     pub async fn reset(
         &self,
         namespace: NamespaceName,


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1396](https://togithub.com/tursodatabase/libsql/pull/1396).



The original branch is fork-1396-avinassh/backport-v0.24.8