### PR TITLE
bump sqld to 0.24.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3348,7 +3348,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.8"
+version = "0.24.9"
 dependencies = [
  "aes",
  "anyhow",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.8"
+version = "0.24.9"
 edition = "2021"
 default-run = "sqld"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1404](https://togithub.com/tursodatabase/libsql/pull/1404).



The original branch is upstream/bump-libsql-server-v0.24.9