### PR TITLE
wal: add buf_copy to limit memory usage

### DIFF
--- a/libsql-wal/src/io/file.rs
+++ b/libsql-wal/src/io/file.rs
@@ -2,7 +2,7 @@ use std::fs::File;
 use std::future::Future;
 use std::io::{self, ErrorKind, IoSlice, Result, Write};
 
-use super::buf::{IoBuf, IoBufMut};
+use super::buf::{IoBuf, IoBufMut, SubChunkBuf};
 
 pub trait FileExt: Send + Sync + 'static {
     fn len(&self) -> io::Result<u64>;
@@ -71,6 +71,74 @@ pub trait FileExt: Send + Sync + 'static {
         buf: B,
         offset: u64,
     ) -> impl Future<Output = (B, Result<()>)> + Send;
+
+    fn buf_copy<F: FileExt, B: IoBufMut + Send + 'static>(
+        &self,
+        dest: &F,
+        buf: B,
+    ) -> impl Future<Output = (B, Result<()>)> + Send
+    where
+        Self: Sized,
+    {
+        async move {
+            let len = match self.len() {
+                Ok(l) => l,
+                Err(e) => return (buf, Err(e)),
+            };
+
+            let mut offset = 0;
+            let mut buf = buf;
+            loop {
+                if (offset + buf.bytes_total() as u64) > len {
+                    let sub_chunk_len = len - offset;
+                    let sub_buf = SubChunkBuf::new(buf, sub_chunk_len as usize);
+
+                    let (buf_out, res) = copy_buf(self, dest, sub_buf, offset).await;
+                    buf = buf_out.into_inner();
+
+                    if res.is_err() {
+                        return (buf, res);
+                    }
+                } else {
+                    let (buf_out, res) = copy_buf(self, dest, buf, offset).await;
+                    buf = buf_out;
+
+                    if res.is_err() {
+                        return (buf, res);
+                    }
+                }
+
+                offset += buf.bytes_total() as u64;
+
+                if offset >= len {
+                    return (buf, Ok(()));
+                }
+            }
+        }
+    }
+}
+
+async fn copy_buf<B: IoBufMut + Send + 'static>(
+    orig: &impl FileExt,
+    dest: &impl FileExt,
+    mut buf: B,
+    offset: u64,
+) -> (B, Result<()>) {
+    let (buf_out, res) = orig.read_exact_at_async(buf, offset).await;
+    buf = buf_out;
+
+    if res.is_err() {
+        return (buf, res);
+    }
+
+    let (buf_out, res) = dest.write_all_at_async(buf, offset).await;
+    buf = buf_out;
+
+    if res.is_err() {
+        return (buf, res);
+    }
+
+    (buf, Ok(()))
 }
 
 impl FileExt for File {
@@ -276,5 +344,49 @@ mod test {
         ret.unwrap();
         assert_eq!(buf.len(), 50);
         assert!(buf.iter().all(|x| *x == 2));
+    }
+
+    #[tokio::test]
+    async fn test_buf_copy_same_size_buffer() {
+        let file1 = tempfile().unwrap();
+        let file2 = tempfile().unwrap();
+
+        let buf = vec![42; 5000];
+        let (_, res) = file1.write_all_at_async(buf, 0).await;
+        res.unwrap();
+
+        let buf = Vec::with_capacity(5000);
+        let (_, res) = file1.buf_copy(&file2, buf).await;
+        res.unwrap();
+
+        let mut buf1 = Vec::with_capacity(5000);
+        let mut buf2 = Vec::with_capacity(5000);
+
+        file1.read_exact_at(&mut buf1[..], 0).unwrap();
+        file2.read_exact_at(&mut buf2[..], 0).unwrap();
+
+        assert_eq!(buf1, buf2);
+    }
+
+    #[tokio::test]
+    async fn test_buf_copy_smaller_buffer() {
+        let file1 = tempfile().unwrap();
+        let file2 = tempfile().unwrap();
+
+        let buf = vec![42; 5000];
+        let (_, res) = file1.write_all_at_async(buf, 0).await;
+        res.unwrap();
+
+        let buf = Vec::with_capacity(512);
+        let (_, res) = file1.buf_copy(&file2, buf).await;
+        res.unwrap();
+
+        let mut buf1 = Vec::with_capacity(5000);
+        let mut buf2 = Vec::with_capacity(5000);
+
+        file1.read_exact_at(&mut buf1[..], 0).unwrap();
+        file2.read_exact_at(&mut buf2[..], 0).unwrap();
+
+        assert_eq!(buf1, buf2);
     }
 }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1454](https://togithub.com/tursodatabase/libsql/pull/1454).



The original branch is upstream/lucio/buf-copy-fs