### PR TITLE
libsql: make errors non-exhaustive

### DIFF
--- a/libsql/src/errors.rs
+++ b/libsql/src/errors.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
 pub enum Error {
     #[error("Failed to connect to database: `{0}`")]
     ConnectionFailed(String),


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1468](https://togithub.com/tursodatabase/libsql/pull/1468).



The original branch is upstream/lucio/make-client-errs-foward-compat