### PR TITLE
Add a link to my (experimental) D driver based on the C driver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The comprehensive description can be found [here](libsql-sqlite3/doc/libsql_exte
 
 ### Community Drivers
 * [PHP](https://github.com/tursodatabase/turso-client-php)
+* [D](https://github.com/pdenapo/libsql-d) (experimental, based on the C driver)
 
 ## Getting Started
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1470](https://togithub.com/tursodatabase/libsql/pull/1470).



The original branch is fork-1470-pdenapo/add-D-bindings-link