### PR TITLE
libsql: release v0.5.0-alpha.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,7 +3338,7 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.4.0"
+version = "0.5.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql"
-version = "0.4.0"
+version = "0.5.0-alpha.1"
 edition = "2021"
 description = "libSQL library: the main gateway for interacting with the database"
 repository = "https://github.com/tursodatabase/libsql"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1488](https://togithub.com/tursodatabase/libsql/pull/1488).



The original branch is upstream/lucio/v0.5.0-alpha.1