### PR TITLE
fix bottomless bug when restoring from uncompressed snapshots

### DIFF
--- a/bottomless/src/replicator.rs
+++ b/bottomless/src/replicator.rs
@@ -1405,7 +1405,7 @@ impl Replicator {
 
         for algo in algos_to_try {
             let main_db_path = match algo {
-                CompressionKind::None => format!("{}-{}/db.db", self.db_name, generation),
+                CompressionKind::None => format!("{}-{}/db.raw", self.db_name, generation),
                 CompressionKind::Gzip => format!("{}-{}/db.gz", self.db_name, generation),
                 CompressionKind::Zstd => format!("{}-{}/db.zstd", self.db_name, generation),
             };


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1493](https://togithub.com/tursodatabase/libsql/pull/1493).



The original branch is upstream/fix-snapshot-restore