### PR TITLE
bump libsql-server 0.24.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3439,7 +3439,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.15"
+version = "0.24.16"
 dependencies = [
  "aes",
  "anyhow",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.15"
+version = "0.24.16"
 edition = "2021"
 default-run = "sqld"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1498](https://togithub.com/tursodatabase/libsql/pull/1498).



The original branch is upstream/bump-libsql-server-v0.24.16