### PR TITLE
Stop using self-hosted runners

### DIFF
--- a/.github/workflows/release-libsql.yml
+++ b/.github/workflows/release-libsql.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       matrix:
         os: 
-          - linux-x86_64
+          - ubuntu-latest
           - macos-14
           - ${{ needs.start-runner.outputs.label }}
         variant: 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1508](https://togithub.com/tursodatabase/libsql/pull/1508).



The original branch is upstream/remove_self_hosted_runners