### PR TITLE
use dedicated destroy_wal_manager function to destroy wal as it can be static

### DIFF
--- a/libsql-sqlite3/src/main.c
+++ b/libsql-sqlite3/src/main.c
@@ -3356,8 +3356,8 @@ static int openDatabase(
   ){
     db->mutex = sqlite3MutexAlloc(SQLITE_MUTEX_RECURSIVE);
     if( db->mutex==0 ){
-      wal_manager->ref.xDestroy(wal_manager->ref.pData);
-      sqlite3_free(db->wal_manager);
+      db->wal_manager->ref.xDestroy(db->wal_manager->ref.pData);
+      destroy_wal_manager(db->wal_manager);
       sqlite3_free(db);
       db = 0;
       goto opendb_out;


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1514](https://togithub.com/tursodatabase/libsql/pull/1514).



The original branch is upstream/fix-wal-manager-destruction