### PR TITLE
add CI job to validate that bundle is up to date

### DIFF
--- a/.github/workflows/c-bindings.yml
+++ b/.github/workflows/c-bindings.yml
@@ -8,6 +8,31 @@ on:
     branches: [ "main" ]
 
 jobs:
+  c-bundle-validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Set up cargo cache
+      uses: actions/cache@v3
+      continue-on-error: false
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: ${{ runner.os }}-cargo-
+
+    - name: Generate C bundle
+      run: cargo xtask build-bundled
+
+    - name: Check that C bundle is up to date
+      run: git diff --quiet || (echo "found uncommited changes in the bundle; please run 'cargo xtask build-bundled' and commit the result" && exit 1)
+
   c-bindings:
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1516](https://togithub.com/tursodatabase/libsql/pull/1516).



The original branch is upstream/build-bundle