### PR TITLE
error out when dump is not a file

### DIFF
--- a/libsql-server/src/error.rs
+++ b/libsql-server/src/error.rs
@@ -286,6 +286,8 @@ pub enum LoadDumpError {
     NoTxn,
     #[error("The dump should commit the transaction.")]
     NoCommit,
+    #[error("Path is not a file")]
+    NotAFile,
 }
 
 impl ResponseError for LoadDumpError {}
@@ -303,6 +305,7 @@ impl IntoResponse for &LoadDumpError {
             | UnsupportedUrlScheme(_)
             | NoTxn
             | NoCommit
+            | NotAFile
             | DumpFilePathNotAbsolute => self.format_err(StatusCode::BAD_REQUEST),
         }
     }

--- a/libsql-server/src/http/admin/mod.rs
+++ b/libsql-server/src/http/admin/mod.rs
@@ -408,6 +408,10 @@ where
                 return Err(LoadDumpError::DumpFileDoesntExist);
             }
 
+            if !path.is_file() {
+                return Err(LoadDumpError::NotAFile);
+            }
+
             let f = tokio::fs::File::open(path).await?;
 
             Ok(Box::new(ReaderStream::new(f)))

--- a/libsql-wal/src/bottomless/storage/fs.rs
+++ b/libsql-wal/src/bottomless/storage/fs.rs
@@ -45,9 +45,9 @@ impl<I: Io> Storage for FsStorage<I> {
 
         let path = self.prefix.join("segments").join(key);
 
-        let buf = Vec::with_capacity(dbg!(segment_data.len().unwrap()) as usize);
+        let buf = Vec::with_capacity(segment_data.len().unwrap() as usize);
 
-        let f = self.io.open(true, false, true, dbg!(&path)).unwrap();
+        let f = self.io.open(true, false, true, &path).unwrap();
         async move {
             let (buf, res) = segment_data.read_exact_at_async(buf, 0).await;
 
@@ -88,10 +88,7 @@ impl<I: Io> Storage for FsStorage<I> {
                     use crate::io::buf::ZeroCopyBuf;
 
                     let header_buf = ZeroCopyBuf::<CompactedSegmentDataHeader>::new_uninit();
-                    let file = self
-                        .io
-                        .open(false, true, false, dbg!(&entry.path()))
-                        .unwrap();
+                    let file = self.io.open(false, true, false, &entry.path()).unwrap();
                     let (header_buf, res) = file.read_exact_at_async(header_buf, 0).await;
                     res.unwrap();
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1526](https://togithub.com/tursodatabase/libsql/pull/1526).



The original branch is upstream/error-dump-not-a-file