### PR TITLE
release libsql v0.5.0-alpha.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "libsql"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/libsql/Cargo.toml
+++ b/libsql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql"
-version = "0.5.0-alpha.1"
+version = "0.5.0-alpha.2"
 edition = "2021"
 description = "libSQL library: the main gateway for interacting with the database"
 repository = "https://github.com/tursodatabase/libsql"


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1548](https://togithub.com/tursodatabase/libsql/pull/1548).



The original branch is upstream/lucio/libsql-0.5.0-alpha.2