### PR TITLE
remove smallvec from parser

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3650,7 +3650,6 @@ dependencies = [
  "phf",
  "phf_codegen",
  "phf_shared",
- "smallvec",
  "uncased",
 ]
 

--- a/vendored/sqlite3-parser/Cargo.toml
+++ b/vendored/sqlite3-parser/Cargo.toml
@@ -30,7 +30,6 @@ phf = { version = "0.11", features = ["uncased"] }
 log = "0.4"
 memchr = "2.0"
 fallible-iterator = "0.3"
-smallvec = ">=1.6.1"
 bitflags = "2.0"
 uncased = "0.9"
 indexmap = "2.0"

--- a/vendored/sqlite3-parser/third_party/lemon/lempar.rs
+++ b/vendored/sqlite3-parser/third_party/lemon/lempar.rs
@@ -174,8 +174,6 @@ pub struct yyStackEntry {
                          ** is the value of the token  */
 }
 
-use smallvec::SmallVec;
-
 /* The state of the parser is completely contained in an instance of
 ** the following structure */
 #[allow(non_camel_case_types)]
@@ -186,7 +184,7 @@ pub struct yyParser<'input> {
     //#[cfg(not(feature = "YYNOERRORRECOVERY"))]
     yyerrcnt: i32, /* Shifts left before out of the error */
 %%                               /* A place to hold %extra_context */
-    yystack: SmallVec<[yyStackEntry; YYSTACKDEPTH]>, /* The parser's stack */
+    yystack: Vec<yyStackEntry>, /* The parser's stack */
 }
 
 use std::cmp::Ordering;
@@ -324,7 +322,7 @@ impl yyParser<'_> {
             yyidx: 0,
             #[cfg(feature = "YYTRACKMAXSTACKDEPTH")]
             yyhwm: 0,
-            yystack: SmallVec::new(),
+            yystack: Vec::with_capacity(YYSTACKDEPTH),
             //#[cfg(not(feature = "YYNOERRORRECOVERY"))]
             yyerrcnt: -1,
 %%               /* Optional %extra_context store */


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1580](https://togithub.com/tursodatabase/libsql/pull/1580).



The original branch is upstream/bump-parser