### PR TITLE
bump sqld to v0.24.18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "libsql-server"
-version = "0.24.17"
+version = "0.24.18"
 dependencies = [
  "aes",
  "anyhow",

--- a/libsql-server/Cargo.toml
+++ b/libsql-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsql-server"
-version = "0.24.17"
+version = "0.24.18"
 edition = "2021"
 default-run = "sqld"
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1588](https://togithub.com/tursodatabase/libsql/pull/1588).



The original branch is upstream/bump-sqld-v0.24.18