### PR TITLE
use gosu instead of native docker USER in the entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:slim-bullseye AS chef
 RUN apt update \
     && apt install -y libclang-dev clang \
         build-essential tcl protobuf-compiler file \
-        libssl-dev pkg-config git tcl cmake \
+        libssl-dev pkg-config git cmake \
     && apt clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -36,6 +36,38 @@ RUN if [ "$ENABLE_FEATURES" == "" ]; then \
     else \
         cargo build -p libsql-server --features "$ENABLE_FEATURES" --release ; \
     fi
+
+# official gosu install instruction (https://github.com/tianon/gosu/blob/master/INSTALL.md)
+FROM debian:bullseye-slim as gosu
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+# save list of currently installed packages for later so we can clean up
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates gnupg wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # runtime
 FROM debian:bullseye-slim
 RUN apt update
@@ -49,9 +81,13 @@ WORKDIR /var/lib/sqld
 USER sqld
 
 COPY docker-entrypoint.sh /usr/local/bin
+COPY docker-wrapper.sh /usr/local/bin
 
+COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /target/release/sqld /bin/sqld
 
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+USER root
+
+ENTRYPOINT ["/usr/local/bin/docker-wrapper.sh"]
 CMD ["/bin/sqld"]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,13 +1,11 @@
 # build sqld
 FROM rust:slim-bullseye as builder
-RUN apt update
-
-RUN apt install -y libclang-dev clang \
+RUN apt update \
+    && apt install -y libclang-dev clang \
         build-essential tcl protobuf-compiler file \
-        libssl-dev pkg-config
-
-RUN apt clean
-RUN update-ca-certificates
+        libssl-dev pkg-config git cmake \
+    && apt clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /sqld
 COPY . .
@@ -18,22 +16,57 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry \
     cp target/release/sqld /sqld/bin
 
 
+# official gosu install instruction (https://github.com/tianon/gosu/blob/master/INSTALL.md)
+FROM debian:bullseye-slim as gosu
+ENV GOSU_VERSION 1.17
+RUN set -eux; \
+# save list of currently installed packages for later so we can clean up
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates gnupg wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	\
+# verify the signature
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	\
+# clean up fetch dependencies
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	\
+	chmod +x /usr/local/bin/gosu; \
+# verify that the binary works
+	gosu --version; \
+	gosu nobody true
+
 # runtime
 FROM debian:bullseye-slim
 RUN apt update
 
-COPY --from=builder /sqld/bin /bin/sqld
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY docker-entrypoint.sh /usr/local/bin
-
+EXPOSE 5001 8080
 VOLUME [ "/var/lib/sqld" ]
 
 RUN groupadd --system --gid 666 sqld
 RUN adduser --system --home /var/lib/sqld --uid 666 --gid 666 sqld
-USER sqld
 WORKDIR /var/lib/sqld
+USER sqld
 
-EXPOSE 5001 8080
+COPY docker-entrypoint.sh /usr/local/bin
+COPY docker-wrapper.sh /usr/local/bin
 
-ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+COPY --from=gosu /usr/local/bin/gosu /usr/local/bin/gosu
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /sqld/bin /bin/sqld
+
+USER root
+
+ENTRYPOINT ["/usr/local/bin/docker-wrapper.sh"]
 CMD ["/bin/sqld"]

--- a/docker-wrapper.sh
+++ b/docker-wrapper.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+SQLD_DB_PATH="${SQLD_DB_PATH:-iku.db}"
+mkdir -p $SQLD_DB_PATH
+chown -R sqld:sqld $SQLD_DB_PATH
+exec gosu sqld docker-entrypoint.sh "$@"

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -44,8 +44,19 @@ mount on your local disk.
 
 ```
 docker run --name some-sqld -ti \
-    -v ./.data/libsql \
+    -v $(pwd)/sqld-data:/var/lib/sqld \ # you can mount local path
     -e SQLD_NODE=primary \
+    ghcr.io/tursodatabase/libsql-server:latest
+
+docker run --name some-sqld -ti \
+    -v sqld-data:/var/lib/sqld \ # or create named volume
+    -e SQLD_NODE=primary \
+    ghcr.io/tursodatabase/libsql-server:latest
+
+docker run --name some-sqld -ti \
+    -v sqld-data:/data/sqld \ # to mount data in different directory set SQLD_DB_PATH env var
+    -e SQLD_NODE=primary \
+    -e SQLD_DB_PATH=/data/sqld \
     ghcr.io/tursodatabase/libsql-server:latest
 ```
 


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1590](https://togithub.com/tursodatabase/libsql/pull/1590).



The original branch is upstream/sqld-docker-file-gosu