### PR TITLE
allow reindex statement in libsql

### DIFF
--- a/libsql-server/src/query_analysis.rs
+++ b/libsql-server/src/query_analysis.rs
@@ -139,6 +139,7 @@ impl StmtKind {
                 ))
             }
             Cmd::Stmt(Stmt::Detach(_)) => Some(Self::Detach),
+            Cmd::Stmt(Stmt::Reindex { .. }) => Some(Self::Write),
             _ => None,
         }
     }

--- a/libsql/src/parser.rs
+++ b/libsql/src/parser.rs
@@ -120,6 +120,7 @@ impl StmtKind {
             }) => Some(Self::Release),
             Cmd::Stmt(Stmt::Attach { .. }) => Some(Self::Attach),
             Cmd::Stmt(Stmt::Detach(_)) => Some(Self::Detach),
+            Cmd::Stmt(Stmt::Reindex { .. }) => Some(Self::Write),
             _ => None,
         }
     }


### PR DESCRIPTION
This pull request was created automatically by CodSpeed to track performance changes of the pull request [tursodatabase/libsql#1598](https://togithub.com/tursodatabase/libsql/pull/1598).



The original branch is upstream/libsql-allow-reindex